### PR TITLE
Adicionar validação para placas do Mercosul

### DIFF
--- a/src/placa.ts
+++ b/src/placa.ts
@@ -138,21 +138,30 @@ export const PLACAS_RANGE = [
 
 export const PLACAS_INVALID = { start: 'SAW0001', end: 'ZZZ9999' } // || Sequências ainda não definidas
 
-export function validate_placa(placa: string | number) {
-  let placaClean: string = placa.toString();
-  placaClean = placaClean.replace(/-/g, '').toUpperCase();
-  const exp = /[A-Za-z]{3}\-\d{4}/;
-  const expClean = /[A-Za-z]{3}\d{4}/;
-  // const letters = placa.substr(0, 3).toUpperCase();
-  const placaString = placa.toString();
-  if (!exp.test(placaString) && !expClean.test(placaClean)) {
-    return false;
+export function validate_placa(placa: string | number, incluiMercosul?: boolean) {
+  const placaClean = placa.toString()
+                          .replace(/-/g, '')
+                          .replace(/ /g, '')
+                          .toUpperCase();
+  const regex = {
+    legadoBR: /[A-Z]{3}[0-9]{4}/,
+    mercosulBR: /[A-Z]{3}[0-9]{1}[A-Z]{1}[0-9]{2}/,
+    mercosulAR: /[A-Z]{2}[0-9]{3}[A-Z]{2}|[A-Z]{1}[0-9]{3}[A-Z]{3}/,
+    mercosulBO: /[A-Z]{2}[0-9]{5}/,
+    mercosulPY: /[A-Z]{4}[0-9]{3}|[0-9]{3}[A-Z]{4}/,
+    mercosulUY: /[A-Z]{3}[0-9]{4}/,
   }
-  const found = placaString >= PLACAS_INVALID.start && placaString <= PLACAS_INVALID.end;
-  if (found) {
-    return false;
-  } else {
+  const isLegadoBRInvalid = 
+                      placaClean >= PLACAS_INVALID.start && placaClean <= PLACAS_INVALID.end;
+  if((regex.legadoBR.test(placaClean) && !isLegadoBRInvalid)
+    || (regex.mercosulBR.test(placaClean))
+    || (incluiMercosul && (
+        (regex.mercosulAR.test(placaClean))
+        || (regex.mercosulBO.test(placaClean))
+        || (regex.mercosulPY.test(placaClean))
+        || (regex.mercosulUY.test(placaClean))
+  ))) {
     return true;
   }
-
+  return false;
 }

--- a/test/validate.ts
+++ b/test/validate.ts
@@ -365,10 +365,38 @@ describe('Validate test', () => {
     });
   });
 
-  it('PLACA', () => {
-    expect(validateBr.placa('ABC1234')).to.be.true;
-    expect(validateBr.placa('SAW0002')).to.be.false;
-    expect(validateBr.placa('1234')).to.be.false;
+  context('PLACA', () => {
+    it('Legado BR', () => {
+      expect(validateBr.placa('ABC1234')).to.be.true;
+      expect(validateBr.placa('SAW0002')).to.be.false;
+      expect(validateBr.placa('1234')).to.be.false;
+    });
+    it('Mercosul BR', () => {
+      expect(validateBr.placa('ABC1D23')).to.be.true;
+      expect(validateBr.placa('ABC 1D23')).to.be.true;
+      expect(validateBr.placa('A1B23DE')).to.be.false;
+      expect(validateBr.placa('AB123DE')).to.be.false;
+    });
+    it('Mercosul AR', () => {
+      expect(validateBr.placa('AB 123 CD', true)).to.be.true;
+      expect(validateBr.placa('A12 3BCD', true)).to.be.true;
+    });
+    it('Mercosul BO', () => {
+      expect(validateBr.placa('AB 12345', true)).to.be.true;
+    });
+    it('Mercosul PY', () => {
+      expect(validateBr.placa('ABCD 123', true)).to.be.true;
+      expect(validateBr.placa('123 ABCD', true)).to.be.true;
+    });
+    it('Mercosul UY', () => {
+      expect(validateBr.placa('ABC 1234', true)).to.be.true;
+    });
+    it('Mercosul Invalid', () => {
+      expect(validateBr.placa('A1BC234', true)).to.be.false;
+      expect(validateBr.placa('A1B2C34', true)).to.be.false;
+      expect(validateBr.placa('A1B23C4', true)).to.be.false;
+      expect(validateBr.placa('AB123C4', true)).to.be.false;
+    });
   });
 
   // it.only('PROCESSO', () => {


### PR DESCRIPTION
O código atual só dá suporte à validação das placas do sistema legado brasileiro. Em razão da introdução do novo sistema de placas do Mercosul, cuja especificação é descrita em https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_the_Mercosur, a função `validate_placa` foi alterada para ser capaz validar as placas brasileiras conforme o padrão legado, bem como segundo o novo padrão do Mercosul. 

Foi incluído também o parâmetro 'incluiMercosul', que faz com que a função verifique opcionalmente se a placa se enquadra no novo sistema de placas segundo o padrão de qualquer um dos outros países integrantes do Mercosul.