### PR TITLE
fix: corrige pasta de testes e exclui outras desnecessarias ao npm #55

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,10 @@
+.github
+.vscode
+docs
 node_modules
-tests
+src
+addons
+test
+.travis.yml
+tsconfig.json
+tslint.json


### PR DESCRIPTION
Corrige .npmignore:

- renomeia `tests` para `test`
- remove src e outras pastas do pacote npm (são desnecessários e só aumentam o tamanho final)