### PR TITLE
fix: ignora apenas diretorios no primeiro nivel

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,11 @@
-.github
-.vscode
-docs
+.github/
+.vscode/
+.idea/
+docs/
 node_modules
-src
-addons
-test
+src/
+addons/
+test/
 .travis.yml
 tsconfig.json
 tslint.json


### PR DESCRIPTION
corrige npmignore para ignorar diretórios apenas na raiz do projeto, parando de ignorar os diretórios src e addons dentro do dist