### PR TITLE
fix: Removendo variáveis declaradas não utilizadas

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chai": "^4.1.2",
     "codelyzer": "^5.2.0",
     "mocha": "^5.2.0",
+    "onchange": "^7.1.0",
     "ts-node": "^7.0.1",
     "typescript": "~4.0.2"
   }

--- a/src/create.ts
+++ b/src/create.ts
@@ -80,10 +80,6 @@ export function create_cnh(cnh: string) {
     dsc = 2;
   }
 
-  for (let i = 0, j = 1, v = 0; i < 9; ++i, ++j) {
-    v += +(parseInt(cnh.charAt(i)) * j);
-  }
-
   let x = v % 11;
   let vl2 = (x >= 10) ? 0 : x - dsc;
 

--- a/src/mask.ts
+++ b/src/mask.ts
@@ -194,7 +194,6 @@ const makeGeneric = (key: string) => {
       return '';
     }
 
-    const test = getSpecialProperty(MASKS, key);
     let mask = MASKS[key].textMask
     let textMaskFunction = MASKS[key].textMaskFunction
     if (typeof textMaskFunction === 'function') {

--- a/src/mask.ts
+++ b/src/mask.ts
@@ -1,4 +1,4 @@
-import { isArray, processCaretTraps, getSpecialProperty } from './utils';
+import { isArray, processCaretTraps } from './utils';
 import { BigObject, MaskType, IEMaskType } from './interfaces';
 import { IEMASKS } from './inscricaoestadual';
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'

--- a/src/rg.ts
+++ b/src/rg.ts
@@ -19,7 +19,6 @@ export function rg_sp(number: string) {
   if (cispDig == 10) {
     cispDig = "X";
   }
-  let cispDV = cispDig;
 
 }
 

--- a/src/rg.ts
+++ b/src/rg.ts
@@ -20,6 +20,7 @@ export function rg_sp(number: string) {
     cispDig = "X";
   }
 
+  return cispDig;
 }
 
 export function rg_rj(number: string) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -73,7 +73,6 @@ export function cep_ranges(cep: string | number) {
   cep = (cep.toString()).replace(/[^\d]+/g, '');
   cep = parseInt(cep, 10);
   const cepString: string = cep.toString();
-  const keys = Object.keys(CEPRange);
   let found: any;
   for (let estado in CEPRange) {
     const v = CEPRange[estado];


### PR DESCRIPTION
Nesta mudança estou removendo algumas variáveis que não são utilizadas no código e uma parte de código repetido (create.ts).

No arquivo `rg.ts`, a função `rg_sp` antes encerrava atribuindo o valor de `cispDig` à uma nova variável chamada `cispDV`. Como não consegui achar referência à isso no código e nos testes, acabei fazendo com que a função retornasse o `cispDig` no final, mantendo a consistência com `rg_rj` presente no mesmo arquivo.

O principal objetivo dessas mudanças é evitar erros de compilação do typescript. Apesar do projeto estar configurado para ignorar esses warnings, quando eu utilizo a js-brasil em outros projetos que validam as libs isso acaba gerando erro no build.