### PR TITLE
Validação de caracteres no input CPF

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -182,8 +182,14 @@ function validate_contabanco(number: any) {
   return true;
 }
 
-// http://www.receita.fazenda.gov.br/aplicacoes/atcta/cpf/funcoes.js
+// http://www.receita.fazenda.gov.br/aplicacoes/atcta/
+/funcoes.js
 export function validate_cpf(strCPF: any) {
+  
+  let precisaFicarVazio = strCPF.replace(/^[0-9.-]*$/gm, '')
+  if (precisaFicarVazio != '')
+    return false
+  
   strCPF = strCPF.replace(/[^\d]+/g, '');
   if (strCPF.length !== 11) {
     return false;


### PR DESCRIPTION
Hoje se testarmos com esse input: (abcde487.547.487-39) o validador aceita.
Com esta implementação, ele continua aceitando hifens e pontos, porém se vier coisa a mais, ele recusa