### PR TITLE
Validação de caracteres no input CNPJ

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -164,6 +164,11 @@ export function validate_cnh(value: string) {
 }
 
 export function validate_cnpj(cnpj: any) {
+  
+  let precisaFicarVazio = cnpj.replace(/^[0-9./-]*$/gm, '')
+  if (precisaFicarVazio != '')
+    return false
+  
   cnpj = cnpj.replace(/[^\d]+/g, '');
   let tamanho = cnpj.length - 2
   const digitos = cnpj.substring(tamanho);


### PR DESCRIPTION
Hoje se testarmos com esse input: (abcde487.547.487/0001-39) o validador aceita.
Com esta implementação, ele continua aceitando hífen, barra e pontos, porém se vier coisa a mais, ele recusa