### PR TITLE
fix: #73, validação de IE GO

### DIFF
--- a/src/inscricaoestadual.ts
+++ b/src/inscricaoestadual.ts
@@ -171,7 +171,10 @@ export const generateInscricaoEstadual: BigObject<Function> = {
       return false;
     }
 
-    if (['10', '11', '15'].indexOf(valor.substring(0, 2)) === -1) {
+    // Verifica os digitos iniciais do estado
+    // Fonte: https://appasp.economia.go.gov.br/Legislacao/arquivos/Secretario/IN/IN_1535_2022.htm
+
+    if (['10', '11', '15', '20'].indexOf(valor.substring(0, 2)) === -1) {
       return false;
     }
 

--- a/test/validate.ts
+++ b/test/validate.ts
@@ -308,6 +308,8 @@ describe('Validate test', () => {
       expect(validateBr.inscricaoestadual('110790650', 'go')).to.be.true;
       expect(validateBr.inscricaoestadual('10.395.974-2', 'go')).to.be.true;
       expect(validateBr.inscricaoestadual('10.395.974-0', 'go')).to.be.false;
+      expect(validateBr.inscricaoestadual('20.024.521-0', 'go')).to.be.true;
+      expect(validateBr.inscricaoestadual('20.124.321-4', 'go')).to.be.false;
     });
     it('Maranhão', () => {
       expect(validateBr.inscricaoestadual('126405328', 'ma')).to.be.true;


### PR DESCRIPTION
Permite validação de inscrição estado de Goiás com o novo digito inicial.

Fonte: https://appasp.economia.go.gov.br/Legislacao/arquivos/Secretario/IN/IN_1535_2022.htm