### PR TITLE
chore: release 2.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-brasil",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Javascript Utils para Brasil (cpf, cnpj...)",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Bumps version to **2.7.1** to publish the currency mask decimal fix.

## What's in this release

- **fix:** `MASKS.currency.textMask` now always forces two decimal positions in real-time input masking ([#91](https://github.com/mariohmol/js-brasil/pull/91), closes [ng-brazil#66](https://github.com/mariohmol/ng-brazil/issues/66))
- **refactor:** `createNumberMask` inlined — `text-mask-addons` runtime dependency removed, js-brasil now has zero dependencies

## After merging

Run to publish:
\`\`\`
npm run publishnpm
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)