### PR TITLE
feat(mask): export createCurrencyMask and createNumberMaskBr with configurable decimal places

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   getSpecialProperty
 } from './utils';
 export { validateBr } from './validate';
+export { createCurrencyMask, createNumberMaskBr } from './mask';
 import * as mask from './mask';
 import { MASKS, MASKSIE } from './mask';
 import { PLACAS_RANGE } from './placa';

--- a/src/mask.ts
+++ b/src/mask.ts
@@ -114,6 +114,26 @@ const maskNumber: any = {
   suffix: ''
 }
 
+export function createCurrencyMask(decimals: number = 2) {
+  const integerMaskFn = createNumberMask({
+    ...maskNumber,
+    prefix: 'R$ ',
+    allowNegative: true,
+    allowDecimal: false,
+  });
+  const decimalDigits = Array(decimals).fill(/\d/);
+  const fn: any = (rawValue: string) => {
+    const intPart = (rawValue || '').split(',')[0];
+    return [...integerMaskFn(intPart), ',', ...decimalDigits];
+  };
+  fn.textMaskRaw = integerMaskFn;
+  return fn;
+}
+
+export function createNumberMaskBr(decimals: number = 2) {
+  return createNumberMask({ ...maskNumber, decimalLimit: decimals });
+}
+
 export const MASKS: BigObject<MaskType> = {
   aih: {
     text: '000000000000-0', // 351923414312-8
@@ -200,20 +220,7 @@ export const MASKS: BigObject<MaskType> = {
   },
   currency: {
     text: '0.000,00',
-    textMask: (() => {
-      const integerMaskFn = createNumberMask({
-        ...maskNumber,
-        prefix: 'R$ ',
-        allowNegative: true,
-        allowDecimal: false,
-      });
-      const fn: any = (rawValue: string) => {
-        const intPart = (rawValue || '').split(',')[0];
-        return [...integerMaskFn(intPart), ',', /\d/, /\d/];
-      };
-      fn.textMaskRaw = integerMaskFn;
-      return fn;
-    })()
+    textMask: createCurrencyMask(2)
   },
   data: {
     text: '00/00/0000',
@@ -245,7 +252,7 @@ export const MASKS: BigObject<MaskType> = {
   },
   number: {
     text: '0.000,00',
-    textMask: createNumberMask(maskNumber)
+    textMask: createNumberMaskBr(2)
   },
   porcentagem: {
     text: '00,00%',
@@ -432,7 +439,9 @@ export const maskBr = {
     }
     return makeGeneric('time')(value)
   },
-  titulo: makeGeneric('titulo')
+  titulo: makeGeneric('titulo'),
+  createCurrencyTextMask: (decimals: number = 2) => createCurrencyMask(decimals),
+  createNumberTextMask: (decimals: number = 2) => createNumberMaskBr(decimals),
 };
 
 

--- a/test/mask.ts
+++ b/test/mask.ts
@@ -1,4 +1,4 @@
-import { maskBr, utilsBr } from '../src/index';
+import { maskBr, utilsBr, createCurrencyMask, createNumberMaskBr } from '../src/index';
 const MASKS = utilsBr.MASKS;
 import { expect } from 'chai';
 
@@ -231,6 +231,49 @@ describe('Mask test', () => {
     expect(lastThree3[0]).to.be.equal(',');
     expect(lastThree3[1]).to.be.instanceof(RegExp);
     expect(lastThree3[2]).to.be.instanceof(RegExp);
+  });
+
+  it('createCurrencyMask - configurable decimal places', () => {
+    const mask2 = createCurrencyMask(2);
+    const result2 = mask2('R$ 100');
+    const last3 = result2.slice(-3);
+    expect(last3[0]).to.be.equal(',');
+    expect(last3[1]).to.be.instanceof(RegExp);
+    expect(last3[2]).to.be.instanceof(RegExp);
+    expect(result2.filter((x: any) => x instanceof RegExp && x.source === '\\d').length).to.be.above(1);
+
+    const mask4 = createCurrencyMask(4);
+    const result4 = mask4('R$ 100');
+    const last5 = result4.slice(-5);
+    expect(last5[0]).to.be.equal(',');
+    expect(last5[1]).to.be.instanceof(RegExp);
+    expect(last5[2]).to.be.instanceof(RegExp);
+    expect(last5[3]).to.be.instanceof(RegExp);
+    expect(last5[4]).to.be.instanceof(RegExp);
+
+    // maskBr convenience method
+    const mask4b = maskBr.createCurrencyTextMask(4);
+    const result4b = mask4b('R$ 100');
+    expect(result4b.slice(-5)[0]).to.be.equal(',');
+    expect(result4b.length).to.be.equal(result4.length);
+  });
+
+  it('createNumberMaskBr - configurable decimal places', () => {
+    const mask2 = createNumberMaskBr(2);
+    // createNumberMask returns a function
+    expect(mask2).to.be.a('function');
+
+    const mask4 = createNumberMaskBr(4);
+    expect(mask4).to.be.a('function');
+
+    // 4-decimal mask should produce longer mask than 2-decimal for same value
+    const result2 = mask2('1234,56');
+    const result4 = mask4('1234,5678');
+    expect(result4.length).to.be.above(result2.length);
+
+    // maskBr convenience method
+    const mask4b = maskBr.createNumberTextMask(4);
+    expect(mask4b).to.be.a('function');
   });
 
   it('PIS/PASEP', () => {


### PR DESCRIPTION
## Summary

Fixes mariohmol/ng-brazil#69 — adds support for configurable decimal places in the real-time **input masks** for `currency` and `number` fields.

- Exports `createCurrencyMask(decimals?)` — factory for the currency textMask function
- Exports `createNumberMaskBr(decimals?)` — factory for the number textMask function
- Adds `maskBr.createCurrencyTextMask(decimals?)` and `maskBr.createNumberTextMask(decimals?)` convenience methods
- Refactors existing `MASKS.currency.textMask` and `MASKS.number.textMask` to use the new factories internally (no behavior change for existing usage)

---

## Problem

The display/formatting functions (`maskBr.currency(value, decimals)`, `maskBr.number(value, decimals)`) already support configurable decimal places. However, the **real-time input masks** (textMask) used with Angular's `[textMask]` directive were hardcoded to 2 decimal places:

```typescript
// Before — hardcoded to 2 decimals
MASKS.currency.textMask = (rawValue) => [...integerMask(rawValue), ',', /\d/, /\d/]
MASKS.number.textMask = createNumberMask({ decimalLimit: 2, ... })
```

Use cases like Brazilian nota fiscal items and medical procedures require 4 decimal places (e.g. `R$ 2,1023`).

---

## Technical Spec

### New exported functions

#### `createCurrencyMask(decimals: number = 2): Function`

Returns a textMask-compatible function that masks currency input with the given number of decimal places.

```typescript
import { createCurrencyMask } from 'js-brasil';

// Default: 2 decimal places (existing behavior)
const mask2 = createCurrencyMask();   // R$ 1.234,56
const mask4 = createCurrencyMask(4);  // R$ 1.234,5678
```

**Implementation:** Builds the integer part mask using the existing `createNumberMask` (with `prefix: 'R$ '`, `allowNegative: true`), then appends `,` followed by `N` `/\d/` regex entries dynamically.

#### `createNumberMaskBr(decimals: number = 2): Function`

Returns a textMask-compatible function for numeric input with the given decimal limit.

```typescript
import { createNumberMaskBr } from 'js-brasil';

const mask2 = createNumberMaskBr();   // 1.234,56
const mask4 = createNumberMaskBr(4);  // 1.234,5678
```

**Implementation:** Wraps the internal `createNumberMask` with `maskNumber` defaults and a dynamic `decimalLimit`.

### Convenience methods on `maskBr`

```typescript
maskBr.createCurrencyTextMask(decimals?: number)  // returns createCurrencyMask(decimals)
maskBr.createNumberTextMask(decimals?: number)    // returns createNumberMaskBr(decimals)
```

### Usage in Angular (ng-brazil / [textMask] directive)

```typescript
// component.ts
import { createCurrencyMask, createNumberMaskBr } from 'js-brasil';

@Component({ ... })
export class MyComponent {
  currencyMask4 = createCurrencyMask(4);
  numberMask4   = createNumberMaskBr(4);
}
```

```html
<!-- template.html -->
<input [textMask]="{mask: currencyMask4}" [(ngModel)]="price" />
<!-- Accepts: R$ 2,1023  -->

<input [textMask]="{mask: numberMask4}" [(ngModel)]="quantity" />
<!-- Accepts: 1.234,5678  -->
```

### Backward compatibility

- `MASKS.currency.textMask` and `MASKS.number.textMask` are refactored to use the new factories with `decimals=2` — **identical behavior to before**.
- All existing tests continue to pass (119 tests green).

---

## Test plan

- [x] `createCurrencyMask(4)` returns a function whose output ends with `,` + 4 `RegExp` entries
- [x] `createNumberMaskBr(4)` returns a function; its mask is longer than the 2-decimal equivalent
- [x] `maskBr.createCurrencyTextMask(4)` delegates correctly to `createCurrencyMask`
- [x] `maskBr.createNumberTextMask(4)` delegates correctly to `createNumberMaskBr`
- [x] All 119 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)